### PR TITLE
Compare fluxes

### DIFF
--- a/bcnz/model/__init__.py
+++ b/bcnz/model/__init__.py
@@ -17,6 +17,7 @@
 
 # Input data
 from .all_filters import all_filters
+from .load_filters import load_filters
 from .extinction_laigle import extinction_laigle
 from .load_seds import load_seds
 from .line_ratios import line_ratios

--- a/bcnz/model/__init__.py
+++ b/bcnz/model/__init__.py
@@ -27,6 +27,7 @@ from .etau_madau import etau_madau
 # Core model estimation.
 from .model_cont import model_cont
 from .model_lines import model_lines
+from .model_lines_gaussian import model_lines_gaussian
 
 # Adjust and rebin.
 from .fmod_adjust import fmod_adjust

--- a/bcnz/model/__init__.py
+++ b/bcnz/model/__init__.py
@@ -32,6 +32,7 @@ from .model_lines_gaussian import model_lines_gaussian
 # Adjust and rebin.
 from .fmod_adjust import fmod_adjust
 from .rebin import rebin
+from .combine_lines import combine_lines
 
 from .cache import cache_model
 from .nb2bb import nb2bb

--- a/bcnz/model/__init__.py
+++ b/bcnz/model/__init__.py
@@ -19,8 +19,10 @@
 from .all_filters import all_filters
 from .load_filters import load_filters
 from .extinction_laigle import extinction_laigle
+from .load_extinction import load_extinction
 from .load_seds import load_seds
 from .line_ratios import line_ratios
+from .etau_madau import etau_madau
 
 # Core model estimation.
 from .model_cont import model_cont

--- a/bcnz/model/combine_lines.py
+++ b/bcnz/model/combine_lines.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2020 Martin B. Eriksen
+# This file is part of BCNz <https://github.com/PAU-survey/bcnz>.
+#
+# BCNz is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BCNz is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BCNz.  If not, see <http://www.gnu.org/licenses/>.
+#!/usr/bin/env python
+# encoding: UTF8
+
+
+def combine_lines(model_lines, line_ratios):
+    """Combine several individual line fluxes together given
+     input ratios
+
+       Args:
+           model_lines (df): Emission line model.
+           line_ratios (dict): Ratio coefficients for each line
+    """
+
+    i = 0
+    for line_key, ratio in line_ratios.items():
+        # test.loc[test.sed == line_key, "flux"] *= ratio
+        sub = model_lines.loc[model_lines.sed == line_key]
+        sub.loc[:, "flux"] *= ratio
+        sub = sub.drop(columns="sed")
+        sub = sub.set_index(["z", "band", "ext_law", "EBV"])
+        if i == 0:
+            output = sub.copy()
+        else:
+            output = output.add(sub)
+        i = i + 1
+
+    output["sed"] = "lines"
+    output = output.reset_index()
+
+    return output

--- a/bcnz/model/etau_madau.py
+++ b/bcnz/model/etau_madau.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+
+def etau_madau(wl, z):
+    """
+    Madau 1995 extinction for a galaxy spectrum at
+    (redshift, wavelenght) defined on a grid (z, wl)
+    """
+    xe = 1.0 + z
+
+    # Madau coefficients
+    l = np.array([1216.0, 1026.0, 973.0, 950.0])
+    c = np.array([3.6e-3, 1.7e-3, 1.2e-3, 9.3e-4])
+    ll = 912.0
+
+    # Lyman series absorption
+    Lyman = np.outer(wl ** 3.46, c / l ** 3.46)
+    sel1 = np.divide.outer(wl, np.outer(l, xe)) < 1.0
+    tau1 = np.sum(np.einsum("ijk,ij->ijk", sel1, Lyman), axis=1).T
+
+    # Photoelectric absorption
+    xc = wl / ll
+    xc3 = xc ** 3
+    photoel = (
+        0.25 * np.einsum("j,ij->ij", xc3, np.subtract.outer(xe ** 0.46, xc ** 0.46))
+        + 9.4
+        * np.einsum("j,ij->ij", xc ** 1.5, np.subtract.outer(xe ** 0.18, xc ** 0.18))
+        - 0.7
+        * np.einsum("i,ij->ij", xc3, np.subtract.outer(xc ** (-1.32), xe ** (-1.32))).T
+        - 0.023 * np.subtract.outer(xe ** 1.68, xc ** 1.68)
+    )
+
+    sel2 = (np.divide.outer(wl, ll * xe) <= 1.0).T
+    tau2 = sel2 * photoel
+
+    # Add all together
+    tau = tau1 + tau2
+    tau = np.einsum("ij,j->ij", tau, wl >= ll)
+    tau = np.clip(tau, 0, 700)
+    etau = np.exp(-tau)
+    return etau

--- a/bcnz/model/fmod_adjust.py
+++ b/bcnz/model/fmod_adjust.py
@@ -25,15 +25,15 @@ def funky_hack(config, syn2real, sed, model_norm):
     """Exactly mimic the cuts Alex was making."""
 
     ratio = syn2real.sel(sed=sed).copy()
-    if sed == 'OIII':
-        ratio[(ratio.z < 0.1) | (0.45 < ratio.z)] = 1.
-    elif sed == 'lines':
+    if sed == "OIII":
+        ratio[(ratio.z < 0.1) | (0.45 < ratio.z)] = 1.0
+    elif sed == "lines":
         flux = model_norm.sel(sed=sed)
-        ratio.values[flux < 0.001*flux.max()] = 1.
+        ratio.values[flux < 0.001 * flux.max()] = 1.0
 
         # Yes, this actually happens in an interval.
-        upper = 0.1226,
-        ratio[(ratio.z > 0.1025) & (ratio.z < upper)] = 1.
+        upper = (0.1226,)
+        ratio[(ratio.z > 0.1025) & (ratio.z < upper)] = 1.0
     else:
         # The continuum ratios are better behaved.
         pass
@@ -45,11 +45,11 @@ def scale_model(config, coeff, model):
     """Directly scale the model as with the data."""
 
     # Transform the coefficients.
-    norm_band = config['norm_band']
-    coeff = coeff[coeff.bb == norm_band][['nb', 'val']]
-    coeff = coeff.set_index(['nb']).to_xarray().val
+    norm_band = config["norm_band"]
+    coeff = coeff[coeff.bb == norm_band][["nb", "val"]]
+    coeff = coeff.set_index(["nb"]).to_xarray().val
 
-    inds = ['band', 'z', 'sed', 'ext_law', 'EBV']
+    inds = ["band", "z", "sed", "ext_law", "EBV"]
     model = model.set_index(inds)
     model = model.to_xarray().flux
     # A copy is needed for funky_hack..
@@ -57,7 +57,7 @@ def scale_model(config, coeff, model):
     model_NB = model.sel(band=coeff.nb.values)
 
     # Scaling the fluxes..
-    synbb = (model_NB.rename({'band': 'nb'})*coeff).sum(dim='nb')
+    synbb = (model_NB.rename({"band": "nb"}) * coeff).sum(dim="nb")
     syn2real = model_norm / synbb
 
     for j, xsed in enumerate(model.sed):
@@ -66,7 +66,7 @@ def scale_model(config, coeff, model):
 
         for i, xband in enumerate(model.band):
             # Here we scale the narrow bands into the broad band system.
-            if str(xband.values).startswith('NB'):
+            if str(xband.values).startswith("NB"):
                 model[i, :, j, :, :] *= syn2real_mod
 
     # Since we can not directly store xarray.
@@ -75,13 +75,19 @@ def scale_model(config, coeff, model):
     return model
 
 
-def fmod_adjust(model_cont, model_lines, coeff=False, use_lines=True,
-                norm_band='', scale_synband=False):
+def fmod_adjust(
+    model_cont,
+    model_lines,
+    coeff=False,
+    use_lines=True,
+    norm_band="",
+    scale_synband=False,
+):
     """Adjust the model to reflect that the syntetic narrow bands is not
        entirely accurate.
 
        Args:
-           model_conf (df): Continuum model.
+           model_cont (df): Continuum model.
            model_lines (df): Emission line model.
            coeff (df): Coeffients for scaling the model.
            use_lines (bool): If including the emission lines.
@@ -89,7 +95,7 @@ def fmod_adjust(model_cont, model_lines, coeff=False, use_lines=True,
            scale_synband (str): If actually scaling with the band.
     """
 
-    config = {'use_lines': use_lines, 'norm_band': norm_band}
+    config = {"use_lines": use_lines, "norm_band": norm_band}
 
     # Here the different parts will have a different zbinning! For the
     # first round I plan adding another layer doing the rebinning. After
@@ -97,12 +103,17 @@ def fmod_adjust(model_cont, model_lines, coeff=False, use_lines=True,
 
     # Special case of not actually doing anything ...
     if not scale_synband:
+        if not use_lines:
+            raise Warning(
+                "Both 'scale_synband' and 'use_lines' are False. \
+                          Combining continuum with lines anyway."
+            )
         comb = pd.concat([model_cont, model_lines])
-        comb = comb.set_index(['band', 'z', 'sed', 'ext_law', 'EBV'])
+        comb = comb.set_index(["band", "z", "sed", "ext_law", "EBV"])
 
         return comb
 
-    assert config['norm_band'], 'Need to specify the normalization band'
+    assert config["norm_band"], "Need to specify the normalization band"
     out_cont = scale_model(config, coeff, model_cont)
     if use_lines:
         out_lines = scale_model(coeff, model_lines)

--- a/bcnz/model/fmod_adjust.py
+++ b/bcnz/model/fmod_adjust.py
@@ -116,7 +116,7 @@ def fmod_adjust(
     assert config["norm_band"], "Need to specify the normalization band"
     out_cont = scale_model(config, coeff, model_cont)
     if use_lines:
-        out_lines = scale_model(coeff, model_lines)
+        out_lines = scale_model(config, coeff, model_lines)
         out = pd.concat([out_cont, out_lines])
     else:
         out = out_cont

--- a/bcnz/model/load_extinction.py
+++ b/bcnz/model/load_extinction.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2020 Martin B. Eriksen
+# This file is part of BCNz <https://github.com/PAU-survey/bcnz>.
+#
+# BCNz is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BCNz is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BCNz.  If not, see <http://www.gnu.org/licenses/>.
+#!/usr/bin/env python
+# encoding: UTF8
+
+from IPython.core import debugger
+import os
+import glob
+import numpy as np
+from pathlib import Path
+import pandas as pd
+from IPython.core import debugger as ipdb
+
+
+def load_extinction(d, suff):
+    """Load extinction curves from path."""
+
+    g = os.path.join(os.path.expanduser(d), "*.{}".format(suff))
+
+    df = pd.DataFrame()
+    for x in glob.glob(g):
+        path = Path(x)
+        sep = "," if path.suffix == ".csv" else " "
+        part = pd.read_table(x, sep=sep, names=["lmb", "k"], comment="#")
+        part["ext_law"] = path.with_suffix("").name
+
+        df = df.append(part, ignore_index=True)
+
+    assert len(df), "No extinction curves found"
+
+    return df

--- a/bcnz/model/load_filters.py
+++ b/bcnz/model/load_filters.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2020 Martin B. Eriksen
+# This file is part of BCNz <https://github.com/PAU-survey/bcnz>.
+#
+# BCNz is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BCNz is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BCNz.  If not, see <http://www.gnu.org/licenses/>.
+#!/usr/bin/env python
+# encoding: UTF8
+
+import os
+from pathlib import Path
+import pandas as pd
+from glob import glob
+
+
+def load_filters(dfilters):
+    """Create a dataframe joining all filters."""
+
+    L = []
+    for x in glob(str(Path(dfilters) / "*")):
+        path = Path(x)
+
+        sep = "," if path.suffix == ".csv" else " "
+        part = pd.read_csv(x, names=["lmb", "response"], comment="#", sep=sep)
+        part["band"] = path.with_suffix("").name
+
+        L.append(part)
+
+    assert len(L), "Filters not found."
+    df = pd.concat(L, ignore_index=True)
+    df = df.set_index("band")
+
+    return df

--- a/bcnz/model/model_cont.py
+++ b/bcnz/model/model_cont.py
@@ -25,7 +25,7 @@ import pandas as pd
 
 from scipy.interpolate import splrep, splev
 from scipy.integrate import trapz, simps
-from .etau_madau import etau_madau
+from bcnz.model import etau_madau
 
 
 def calc_r_const(filters):

--- a/bcnz/model/model_lines_gaussian.py
+++ b/bcnz/model/model_lines_gaussian.py
@@ -1,0 +1,178 @@
+# Copyright (C) 2020 Martin B. Eriksen
+# This file is part of BCNz <https://github.com/PAU-survey/bcnz>.
+#
+# BCNz is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# BCNz is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with BCNz.  If not, see <http://www.gnu.org/licenses/>.
+#!/usr/bin/env python
+# encoding: UTF8
+
+from __future__ import print_function
+
+from IPython.core import debugger as ipdb
+import time
+import numpy as np
+import pandas as pd
+
+from scipy.interpolate import splrep, splev
+from scipy.integrate import trapz, simps
+from scipy.stats import norm
+
+from bcnz.model import etau_madau
+
+
+def calc_r_const(filters):
+    """Normalization factor for each filter."""
+
+    # 2.5*log10(clight_AHz) = 46.19205, which you often see applied to
+    # magnitudes.
+    # clight_AHz = 2.99792458e18
+
+    r_const = pd.Series()
+    fL = filters.index.unique()
+    for fname in fL:
+        sub = filters.loc[fname]
+        r_const[fname] = 1.0 / simps(sub.response / sub.lmb, sub.lmb)  # / clight_AHz
+
+    return r_const
+
+
+def sed_spls(seds):
+    """Create a spline of all the SEDs."""
+
+    sedD = {}
+    for sed in seds.index.unique():
+        sub_sed = seds.loc[sed]
+        spl_sed = splrep(sub_sed.lmb, sub_sed.response)
+
+        sedD[sed] = spl_sed
+
+    return sedD
+
+
+def calc_ext_spl(ext, config):
+    """Spline for the extinction."""
+
+    sub = ext[ext.ext_law == config["ext_law"]]
+    ext_spl = splrep(sub.lmb, sub.k)
+
+    return ext_spl
+
+
+def calc_ab(config, filters, lines, ext, r_const):
+    """Estimate the fluxes for all filters and SEDs."""
+
+    abfactor = 10 ** (-0.4 * 48.6)
+
+    ext_spl = calc_ext_spl(ext, config)
+    z = np.arange(0.0, config["zmax_ab"], config["dz_ab"])
+
+    # Test...
+    df = pd.DataFrame()
+
+    int_method = config["int_method"]
+    a = 1.0 / (1 + z)
+    for i, band in enumerate(filters.index.unique()):
+        print("# band", i, "band", band)
+
+        sub_f = filters.loc[band]
+
+        # Define a higher resolution grid.
+        _tmp = sub_f.lmb
+        int_dz = config["int_dz"]
+        lmb = np.arange(_tmp.min(), _tmp.max(), int_dz)
+
+        tau = etau_madau(lmb, z)
+
+        # Evaluate the filter on this grid.
+        spl_f = splrep(sub_f.lmb, sub_f.response)
+        y_f = splev(lmb, spl_f, ext=1)
+
+        X = np.outer(a, lmb)
+
+        # Only looping over the configured SEDs.
+        for line_key, lmb0 in lines.items():
+            t1 = time.time()
+
+            k_ext = splev(X, ext_spl)
+            EBV = config["EBV"]
+            y_ext = 10 ** (-0.4 * EBV * k_ext)
+            y_sed = norm.pdf(X, lmb0, config["line_width"])
+
+            Y = y_ext * y_sed * y_f * lmb * tau
+
+            if int_method == "simps":
+                ans = r_const[band] * simps(Y, lmb, axis=1)
+            elif int_method == "sum":
+                ans = r_const[band] * int_dz * Y.sum(axis=1)
+
+            ans *= config["line_flux"] * abfactor
+            # This might be overkill in terms of storage, but information in
+            # the columns is a pain..
+            part = pd.DataFrame({"z": z, "flux": ans})
+            part["band"] = band
+            part["sed"] = line_key
+            part["ext_law"] = config["ext_law"]
+            part["EBV"] = EBV
+
+            df = df.append(part, ignore_index=True)
+
+            t2 = time.time()
+            print(t2 - t1)
+
+    return df
+
+
+def model_lines_gaussian(
+    filters,
+    lines,
+    ext,
+    ext_law,
+    EBV,
+    line_width=10,
+    line_flux=1e-17,
+    zmax_ab=2.05,
+    dz_ab=0.001,
+    int_dz=1.0,
+    int_method="simps",
+):
+    """The model fluxes for Gaussian emission lines
+       Args:
+           filters (df): Filter transmission curves.
+           lines (dict): Emission line names and wavelength
+           ext (df): Extinction curves.
+           ext_law (str): Extinction law.
+           EBV (float): Extinction value.
+           line_width (float): Emission line width in Angstroms
+           line_flux (float): Emission line total flux in erg/cm/cm/s
+           zmax_ab (float): Maximum redshift in the flux model.
+           dz_ab (float): Redshift resolution in the flux model.
+           int_dz (float): Resolution when integration.
+           int_method (str): Integration method:
+
+    """
+
+    config = {
+        "ext_law": ext_law,
+        "EBV": EBV,
+        "zmax_ab": zmax_ab,
+        "dz_ab": dz_ab,
+        "int_dz": int_dz,
+        "int_method": int_method,
+        "line_width": line_width,
+        "line_flux": line_flux,
+    }
+
+    r_const = calc_r_const(filters)
+    ab = calc_ab(config, filters, lines, ext, r_const)
+
+    return ab


### PR DESCRIPTION
**This PR brings several changes to create the flux models used in the Bayesian Evidence version of the BCNZ code.**

Here is a summary of the changes:

- It brings `bcnz/model/model_lines_gaussian.py`, which computes model fluxes for individual emission lines that are modelled as Gaussian with a certain width. This returns a similar dataframe to `model_lines_cont.py`, where the column `sed` contains an entry for each emission line.

- It brings `bcnz/model/combine_lines.py`, which combines the lines (or a subset) from `model_lines_gaussian.py` into a single sed called `lines` given a dictionary with line names and their line ratios.

- It brings `bcnz/model/etau_madau.py`, which implements the intergalactic extinction from Madau 1995.

- It brings `bcnz/model/load_filters.py` and `bcnz/model/load_extinction.py`, which allow one to load filters or extinction curves from any path, similar to `load_seds.py`.

- It modifies `bcnz/model/model_cont.py` to apply the `etau_madau` extinction.

- It modifies `bcnz/model/fmod_adjust.py` to use a different `funky_hack` that is more general and clean than the previous one, to avoid numerical problems in the scaling correction for emission lines.

- It modifies `bcnz/model/__init__.py` to incorporate all the new scripts.

- The text editor used automatically implements some PEP8 formatting. There are several changes related to that.

**Validation plots**

Here are some validation plots comparing to benchmark calculations from local code.

- This plot shows the computed flux for a continuum template. This includes the `etau_madau` extinction. If the residuals are within 0.001 fractional flux, the differences are negligible.

![compare_fluxes_cont](https://user-images.githubusercontent.com/22844262/100028925-9fe75300-2db5-11eb-8fbe-b86257b5807e.png)

- This plot shows the computed flux for a continuum template, and including Calzetti extinction.

![compare_fluxes_cont_ext](https://user-images.githubusercontent.com/22844262/100029027-eb016600-2db5-11eb-8868-9a9b76d17891.png)

- This plot shows the flux for the OII emission line. No extinction here.

![compare_fluxes_emlines_OII](https://user-images.githubusercontent.com/22844262/100029107-15532380-2db6-11eb-8e2f-ea01226abd4a.png)

- This plot compares the coefficients that define the synthetic Subaru _r_ broad band from the PAUS narrow bands

![compare_nb2bb](https://user-images.githubusercontent.com/22844262/100029146-2bf97a80-2db6-11eb-9a81-d9a61567fbdc.png)

- This plot shows that `bcnz/model/combine_lines.py`, which combines lines with different input ratios, works. 

![test_combine_lines](https://user-images.githubusercontent.com/22844262/100029183-53e8de00-2db6-11eb-8084-700bae55b550.png)

- This plot shows that scaling with the synthetic band works for both continuum and emission line flux. This also includes extinction, and is using all the previous validated scripts.

![test_model_creation](https://user-images.githubusercontent.com/22844262/100029258-81ce2280-2db6-11eb-8967-86c52c9f581f.png)

