### PR TITLE
Changing the reading-in of VIPERS to calibrate W1.

### DIFF
--- a/bcnz/specz/vipers.py
+++ b/bcnz/specz/vipers.py
@@ -12,9 +12,9 @@ def vipers(engine, quality_cut=False):
     df_in = pd.read_csv(d / 'vipers_full.csv', comment='#')
 
     if quality_cut:
-        df = df_in[(3 <= df_in.zflg) & (df_in.zflg <= 4)]
+        df_in = df_in[(3 <= df_in.zflg) & (df_in.zflg <= 4)]
 
-    df = df.rename(columns={'alpha': 'ra', 'delta': 'dec'})
+    df = df_in.rename(columns={'alpha': 'ra', 'delta': 'dec'})
 
     # Selecting W1 field.
     df = df[df.ra < 50]


### PR DESCRIPTION
When selecting the galaxies from VIPERS, the default is set to `quality_cut=False `. This causes an error in line 17 since `df` is not defined above. 