### PR TITLE
Changes when reading from external catalogues

### DIFF
--- a/bcnz/bin/bcnz_externalfile.py
+++ b/bcnz/bin/bcnz_externalfile.py
@@ -39,7 +39,7 @@ def paus_fromfile(mock_cat,bbnaming,bbfit,min_nb=35,
  
 
     paudm_coadd = bcnz.data.load_coadd_file(mock_cat)
-    parent_cat =  pd.read_csv(mock_cat)#.set_index('ref_id')   
+    parent_cat =  pd.read_csv(mock_cat)   
     specz = parent_cat[['ref_id','zspec']].drop_duplicates()
     parent_cat = parent_cat[parent_cat.band.isin(bbnaming)]
 
@@ -50,6 +50,7 @@ def paus_fromfile(mock_cat,bbnaming,bbfit,min_nb=35,
     parent_cat_df = parent_cat.pivot(index = 'ref_id', columns = 'band', values = 'flux_error').rename(columns=dict(zip(bbnaming,bbnaming_error))).reset_index()
     parent_cat_f = parent_cat.pivot(index = 'ref_id', columns = 'band', values = 'flux').reset_index()
     parent_cat = parent_cat_f.merge(parent_cat_df, on = 'ref_id')
+    parent_cat.set_index('ref_id', inplace = True)
 
 
 

--- a/bcnz/data/paudm_coadd.py
+++ b/bcnz/data/paudm_coadd.py
@@ -142,6 +142,8 @@ def load_coadd_file(coadd_file):
     """
 
     coadd = pd.read_csv(coadd_file)
+    column_name = [f'NB{x}' for x in 455+10*np.arange(40)]
+    coadd = coadd[coadd.band.isin(column_name)]
 
     # Shouldn't be correct, but I want to test if it makes a difference.
     coadd['flux'] *= 0.625


### PR DESCRIPTION
Changes in the paudm_coadd file to only select the narrow bands from the external catalogue when reading from an external catalogue. Changes in the bcnz_externalfile to set the ref_id as an index.